### PR TITLE
update add-cluster to use kubeconfigURL

### DIFF
--- a/backend/clients.go
+++ b/backend/clients.go
@@ -3,6 +3,7 @@ package main
 import (
 	"container/heap"
 	"fmt"
+	"log"
 
 	shipwrightClient "github.com/shipwright-io/build/pkg/client/clientset/versioned"
 	"k8s.io/client-go/discovery"
@@ -24,9 +25,9 @@ func getNewClusterRestConfig() (*rest.Config, error) {
 	var newClusterRestConfig *rest.Config
 	for len(clusterPool) > 0 {
 		newCluster := heap.Pop(&clusterPool).(*cluster)
-		newClusterRestConfig, err := getRestConfigFromBytes([]byte(newCluster.KubeConfigContents))
+		newClusterRestConfig, err := getRestConfigFromBytes(newCluster.KubeConfigContents)
 		if err != nil {
-			fmt.Errorf("error retrieving new cluster rest config: %v, Trying different cluster", err.Error())
+			log.Printf("error retrieving new cluster rest config: %v, Trying different cluster", err.Error())
 			continue
 		} else if newClusterRestConfig != nil {
 			currentClusterRestConfig = newClusterRestConfig

--- a/backend/types.go
+++ b/backend/types.go
@@ -27,7 +27,7 @@ type DockerConfigJSON struct {
 type DockerConfig map[string]DockerConfigEntry
 
 type cluster struct {
-	KubeConfigContents string
+	KubeConfigContents []byte
 	Expires            time.Time
 
 	Index int // The index of the item in the heap.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Updates cluster addition mechanism to use kubeconfig URL instead of kubeconfig string contents 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #2 

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:
